### PR TITLE
Ensure *.sh files are LF in ModernizeYourDatabases2019 workshop

### DIFF
--- a/ModernizeYourDatabases2019/.gitattributes
+++ b/ModernizeYourDatabases2019/.gitattributes
@@ -1,0 +1,1 @@
+*.sh		text eol=lf


### PR DESCRIPTION
Especially git on windows tends to checkout text-files with CRLF line-ending (depending on configuration). This is not a good idea for all .sh-files. Adding this .gitattributes file ensures that all *.sh files in the directory containing the file and its sub/directories are always checked out with LF line-endings.