### PR TITLE
Fixing layout of icons in GroundToCloud workshops

### DIFF
--- a/SQLGroundToCloud/README.md
+++ b/SQLGroundToCloud/README.md
@@ -23,7 +23,7 @@ This README.MD file explains how the workshop is laid out, what you will learn, 
 <p style="border-bottom: 1px solid lightgrey;"></p>
 
 
-<img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/checkmark.png?raw=true"> <h3>Learning Objectives</h3>
+<h3><img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/checkmark.png?raw=true"> Learning Objectives</h3>
 
 In this day-long, hands-on Workshop you’ll learn how to:
 
@@ -39,7 +39,7 @@ In this day-long, hands-on Workshop you’ll learn how to:
  - Make informed decisions about how your business or customers should modernize their data estate
  - Use Big Data solutions
 
-<img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/checkmark.png?raw=true"> <h3>Role Applications</h3>
+<h3><img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/checkmark.png?raw=true"> Role Applications</h3>
 
 The concepts and skills taught in this workshop form the starting points for:
 
@@ -48,7 +48,7 @@ The concepts and skills taught in this workshop form the starting points for:
 - Data Scientists, to understand the environment used to analyze and solve specific predictive problems.
 
 <p style="border-bottom: 1px solid lightgrey;"></p>
-<img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/building1.png?raw=true"> <h2>Business Applications of this Workshop</h2>
+<h2><img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/building1.png?raw=true"> Business Applications of this Workshop</h2>
 
 Businesses require near real-time insights from ever-larger sets of data from a variety of sources. Many have not explored the improvements made in the latest versions of SQL Server, and some are only now exploring the cloud as a computing platform. As time has progressed, a more dramatic upgrade process may be required.
 
@@ -56,7 +56,7 @@ In addition to traditional Online Transaction Processing (OLTP) and Online Analy
 
 <p style="border-bottom: 1px solid lightgrey;"></p>
 
-<img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/listcheck.png?raw=true"> <h2><a name="technologies">Technologies and Topics covered in this Workshop</a></h2>
+<h2><img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/listcheck.png?raw=true"> <a name="technologies">Technologies and Topics covered in this Workshop</a></h2>
 
 The information covered in this workshop includes the following technologies and topics - although you are not limited to these, they form the basis of the workshop. At the end of the workshop you will learn how to extrapolate these components into other solutions. You will cover these at an overview level, with references to much deeper training provided.
 
@@ -74,7 +74,7 @@ The information covered in this workshop includes the following technologies and
 
 <p style="border-bottom: 1px solid lightgrey;"></p>
 
-<img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/owl.png?raw=true"> <h2><a name="prereqs">Before Taking this Workshop</a></h2>
+<h2><img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/owl.png?raw=true"> <a name="prereqs">Before Taking this Workshop</a></h2>
 
 You'll need a local system or Virtual Machine that you are able to install software on. The workshop demonstrations use Microsoft Windows as an operating system and all examples use Windows for the workshop. Optionally, you can use a Microsoft Azure Virtual Machine (VM) to install the software on and work with the solution.
 
@@ -88,13 +88,13 @@ If you are new to these, here are a few references you can complete prior to cla
 -  [Microsoft Azure](https://docs.microsoft.com/en-us/learn/paths/azure-fundamentals/)
 
 
-<img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/bulletlist.png?raw=true"> <h3>Setup</h3>
+<h3><img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/bulletlist.png?raw=true"> Setup</h3>
 
 <a href="https://github.com/microsoft/sqlworkshops/blob/master/SQLGroundToCloud/sqlgroundtocloud/00-prerequisites.md" target="_blank">A full prerequisites document is located here</a>. These instructions should be completed before the workshop starts, since you will not have time to cover these in class. <i>Remember to "Stop" any Virtual Machines from the Azure Portal when not taking the class so that you do incur charges (shutting down the machine in the VM itself is not sufficient)</i>.
 
 <p style="border-bottom: 1px solid lightgrey;"></p>
 
-<img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/bulletlist.png?raw=true"> <h3>Intended Audience</h3>
+<h3><img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/bulletlist.png?raw=true"> Intended Audience</h3>
 
 <p>The following roles will find this workshop useful. Others may also attend, as described in the Secondary Audience section.</p>
 
@@ -110,7 +110,7 @@ If you are new to these, here are a few references you can complete prior to cla
 
 <p style="border-bottom: 1px solid lightgrey;"></p>
 
-<img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/bookpencil.png?raw=true"> <h3>Workshop Modules and In-Class Agenda</h3>
+<h3><img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/bookpencil.png?raw=true"> Workshop Modules and In-Class Agenda</h3>
 
 This is a modular workshop, and in each section, you'll learn concepts, technologies and processes to help you complete the solution. The times shown below are for an instructor-led course, you may also take the modules in a self-paced fashion.
 
@@ -160,7 +160,7 @@ This is a modular workshop, and in each section, you'll learn concepts, technolo
 
 <p style="border-bottom: 1px solid lightgrey;"></p>
 
-<img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/pinmap.png?raw=true"> <h2>Related Workshops</h2>
+<h2><img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/pinmap.png?raw=true"> Related Workshops</h2>
 
  - [Other SQL Workshops by Microsoft](https://aka.ms/sqlworkshops)
 

--- a/SQLGroundToCloud/README.md
+++ b/SQLGroundToCloud/README.md
@@ -52,7 +52,15 @@ The concepts and skills taught in this workshop form the starting points for:
 
 Businesses require near real-time insights from ever-larger sets of data from a variety of sources. Many have not explored the improvements made in the latest versions of SQL Server, and some are only now exploring the cloud as a computing platform. As time has progressed, a more dramatic upgrade process may be required.
 
-In addition to traditional Online Transaction Processing (OLTP) and Online Analytic Processing (OLAP) workloads, some industry examples of data processing from multiple sources of data at scale are in Retail (Demand Prediction, Market-Basket Analysis), Finance (Fraud detection, customer segmentation), Healthcare (Fiscal control analytics, Disease Prevention prediction and classification, Clinical Trials optimization), Public Sector (Revenue prediction, Education effectiveness analysis), Manufacturing (Predictive Maintenance, Anomaly Detection) and Agriculture (Food Safety analysis, Crop forecasting) to name just a few.
+In addition to traditional Online Transaction Processing (OLTP) and Online Analytic Processing (OLAP) workloads, some industry examples of data processing from multiple sources of data at scale are:
+|Industry|Example|
+|-|-|
+|Retail|Demand Prediction<br/>Market-Basket Analysis|
+|Finance|Fraud detection<br/>customer segmentation|
+|Healthcare|Fiscal control analytics<br/>Disease Prevention prediction and classification<br/> Clinical Trials optimization|
+|Public Sector|Revenue prediction<br/>Education effectiveness analysis|
+|Manufacturing|Predictive Maintenance<br/>Anomaly Detection|
+|Agriculture|Food Safety analysis<br/>Crop forecasting|
 
 <p style="border-bottom: 1px solid lightgrey;"></p>
 

--- a/SQLGroundToCloud/README.md
+++ b/SQLGroundToCloud/README.md
@@ -53,14 +53,15 @@ The concepts and skills taught in this workshop form the starting points for:
 Businesses require near real-time insights from ever-larger sets of data from a variety of sources. Many have not explored the improvements made in the latest versions of SQL Server, and some are only now exploring the cloud as a computing platform. As time has progressed, a more dramatic upgrade process may be required.
 
 In addition to traditional Online Transaction Processing (OLTP) and Online Analytic Processing (OLAP) workloads, some industry examples of data processing from multiple sources of data at scale are:
-|Industry|Example|
-|-|-|
-|Retail|Demand Prediction<br/>Market-Basket Analysis|
-|Finance|Fraud detection<br/>customer segmentation|
-|Healthcare|Fiscal control analytics<br/>Disease Prevention prediction and classification<br/> Clinical Trials optimization|
-|Public Sector|Revenue prediction<br/>Education effectiveness analysis|
-|Manufacturing|Predictive Maintenance<br/>Anomaly Detection|
-|Agriculture|Food Safety analysis<br/>Crop forecasting|
+<table style="tr:nth-child(even) {background-color: #f2f2f2;}; text-align: left; display: table; border-collapse: collapse; border-spacing: 2px; border-color: gray;">
+<tr><th style="background-color: #1b20a1; color: white;">Industry</th><th style="background-color: #1b20a1; color: white;">Example</th></tr>
+<tr><td style="vertical-align: top">Retail</td><td style="vertical-align: top">Demand Prediction<br/>Market-Basket Analysis</td></tr>
+<tr><td style="vertical-align: top">Finance</td><td style="vertical-align: top">Fraud detection<br/>customer segmentation</td></tr>
+<tr><td style="vertical-align: top">Healthcare</td><td style="vertical-align: top">Fiscal control analytics<br/>Disease Prevention prediction and classification<br/> Clinical Trials optimization</td></tr>
+<tr><td style="vertical-align: top">Public Sector</td><td style="vertical-align: top">Revenue prediction<br/>Education effectiveness analysis</td></tr>
+<tr><td style="vertical-align: top">Manufacturing</td><td style="vertical-align: top">Predictive Maintenance<br/>Anomaly Detection</td></tr>
+<tr><td style="vertical-align: top">Agriculture</td><td style="vertical-align: top">Food Safety analysis<br/>Crop forecasting</td></tr>
+</table>
 
 <p style="border-bottom: 1px solid lightgrey;"></p>
 

--- a/SQLGroundToCloud/README.md
+++ b/SQLGroundToCloud/README.md
@@ -6,7 +6,7 @@
 
 <p style="border-bottom: 1px solid lightgrey;"></p>
 
-<img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/textbubble.png?raw=true"> <h2>About this Workshop</h2>
+<h2><img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/textbubble.png?raw=true"> About this Workshop</h2>
 
 Welcome to this Microsoft solutions workshop on SQL Server in on-premises, in-cloud and hybrid solutions. In this one-day workshop, you'll  learn how SQL Server 2019 and Azure SQL help you solve real-world challenges. 
 

--- a/SQLGroundToCloud/sqlgroundtocloud/05-MigratingToAzureSQL.md
+++ b/SQLGroundToCloud/sqlgroundtocloud/05-MigratingToAzureSQL.md
@@ -6,7 +6,7 @@
 
 <p style="border-bottom: 1px solid lightgrey;"></p>
 
-<img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/textbubble.png?raw=true"> <h2> 05 - Migrate to Azure SQL </h2>
+<h2><img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/textbubble.png?raw=true"> 05 - Migrate to Azure SQL </h2>
 
 In the previous module, you learned about Azure SQL, the benefits, the options, and how to get there. You reviewed how to assess your on-premises estate, and in this module you'll actually migrate to [Azure SQL Database Managed Instance](https://docs.microsoft.com/en-us/azure/sql-database/sql-database-managed-instance).  
 
@@ -93,7 +93,7 @@ Complete activities 1-3 by following the links below. Once you're in Activity 1,
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a name="5.2.3"><a href="https://github.com/microsoft/sqlworkshops/blob/master/AzureSQLLabs/Lab-MigratingToAzureSQLManagedInstance.md#Activity-2-3">Activity 3</a>: Review Advanced Data Security Vulnerability Assessment  
 
 <p style="border-bottom: 1px solid lightgrey;"></p>
-<h2><a name="5.3">5.3 Use online secondary for read-only queries (<i>Bonus</i>)</h2></a>
+<h2><img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/pencil2.png?raw=true"><a name="5.3">5.3 Use online secondary for read-only queries (<i>Bonus</i>)</h2></a>
 
 In this exercise, you will look at how you can use the automatically created online secondary for reporting, without feeling the impacts of a heavy transactional load on the primary database. Each database in the SQL MI Business Critical tier is automatically provisioned with several AlwaysON replicas to support the availability SLA. Using [**Read Scale-Out**](https://docs.microsoft.com/azure/sql-database/sql-database-read-scale-out) allows you to load balance Azure SQL Database read-only workloads using the capacity of one read-only replica.  
 

--- a/SQLGroundToCloud/sqlgroundtocloud/06-WhatToUseWhen.md
+++ b/SQLGroundToCloud/sqlgroundtocloud/06-WhatToUseWhen.md
@@ -6,7 +6,7 @@
 
 <p style="border-bottom: 1px solid lightgrey;"></p>
 
-<img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/textbubble.png?raw=true"> <h2> 06 - What to Use When: Designing a Solution </h2>
+<h2><img style="float: left; margin: 0px 15px 15px 0px;" src="https://github.com/microsoft/sqlworkshops/blob/master/graphics/textbubble.png?raw=true"> 06 - What to Use When: Designing a Solution </h2>
 
 In this workshop you have covered using SQL Server both on-premises and in-cloud configurations, as well as hybrid applications as a solution for data processing. The end of this Module contains several helpful references you can use in these exercises and in production.
 


### PR DESCRIPTION
Icons were on new lines and not next to the headers. Fixing that in this PR.