### PR TITLE
Change msql images version from 2.2 -> 3.2

### DIFF
--- a/SQLonOpenShift/sqlonopenshift/01_deploy/sqldeployment.yaml
+++ b/SQLonOpenShift/sqlonopenshift/01_deploy/sqldeployment.yaml
@@ -14,7 +14,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: mssql
-        image: mcr.microsoft.com/mssql/rhel/server:2019-CTP2.2
+        image: mcr.microsoft.com/mssql/rhel/server:2019-CTP3.2
         ports:
         - containerPort: 1433
         env:


### PR DESCRIPTION
Fixed the error `The evaluation period has expired`
The following diagnostic information is available:
       Reason: 0x00000003
       Status: 0x00000000
      Message: Unexpected call to legacy ABI.